### PR TITLE
Adds error handling for empty inputs and incorrect powerpoint extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 scratch/
 assets/
 virt/
-_pycache_/
+__pycache__/
 .DS_Store
 
 # PYTHON ITEMS (from Github)

--- a/errorHandler.py
+++ b/errorHandler.py
@@ -1,0 +1,18 @@
+import customtkinter
+from tkinter import *
+
+def createErrorWindow(errors):
+    window = customtkinter.CTkToplevel()
+    window.geometry("300x150")
+    window.title("Errors Found")
+
+    windowTitle = customtkinter.CTkLabel(window, text="Please fix the following and submit again.")
+    windowTitle.grid(row=0, column=0, padx=0, pady=5, ipady=0)
+    window.grid_rowconfigure(1, weight=0)
+    window.grid_columnconfigure(0, weight=1)   
+    rowNum = 1
+
+    for x in errors:
+        label = customtkinter.CTkLabel(window, text="- " + x)
+        label.grid(row=rowNum, column=0, padx=(25,0), pady=0, ipady=0, sticky="w")
+        rowNum = rowNum + 1

--- a/powerPresenter.py
+++ b/powerPresenter.py
@@ -28,9 +28,7 @@ def getValues(ppFileName):
     errors = errorHandling(excelFile, ppFileName, row, col)
 
     if errors:
-        print("errors found")
-        createErrorWindow()
-        # getErrors(errors)
+        createErrorWindow(errors)
     else:
         powerPresentation(excelFile, ppFileName, row, col)
 
@@ -66,10 +64,17 @@ def errorHandling(excelFile, ppFile, row, col):
     return errors
 
 def isFileNameValid(fileName):
-    return fileName + ".pptx" if isinstance(fileName, str) else FALSE
+    nameSplit = os.path.split(fileName)
+    root, ext = os.path.splitext(nameSplit[1])
+
+    if(root and root != " "):
+        return fileName if(ext == ".pptx") else nameSplit[0] + "/" + root + ".pptx"
+        # eventually double check if ext was actually a part of the desired file name
+    else:
+        return FALSE
      
 def isExcelFileValid(filepath):
-    return filepath if isinstance(filepath, str) else FALSE 
+    return filepath if (filepath and filepath != " ") else FALSE 
 
 def isHeadeRowValid(row):
     return int(row) if row and isinstance(int(row), int) else FALSE 


### PR DESCRIPTION
- Displays an error window and stops the creation of a power point if any of the user inputs are submitted empty. 
- If the power point file name input has an extension that's not ".pptx" it will keep the file path and name, but replace the extension with ".pptx."
Closes #1 